### PR TITLE
fix: replace exit() with sys.exit() for CodeQL

### DIFF
--- a/catc-mcp-server/catc_mcp_server.py
+++ b/catc-mcp-server/catc_mcp_server.py
@@ -25,6 +25,7 @@ Author: Patrick Mosimann
 """
 
 import os
+import sys
 import base64
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -477,7 +478,7 @@ if __name__ == "__main__":
         print("✅ Successfully authenticated with Catalyst Center")
     else:
         print("❌ Failed to authenticate with Catalyst Center")
-        exit(1)
+        sys.exit(1)
     
     # Start the MCP server
     mcp.run(transport="http", host=mcp_host, port=mcp_port)

--- a/ise-mcp-server/ise_mcp_server.py
+++ b/ise-mcp-server/ise_mcp_server.py
@@ -51,6 +51,7 @@ Based on: https://github.com/automateyournetwork/ISE_MCP
 
 import os
 import re
+import sys
 import requests
 import urllib3
 from pathlib import Path
@@ -756,6 +757,6 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"❌ Failed to connect to ISE API: {e}")
         print("💡 Please check your ISE credentials, host connectivity, and ERS API status")
-        exit(1)
+        sys.exit(1)
 
     mcp.run(transport="http", host=mcp_host, port=mcp_port)

--- a/meraki-mcp-server/meraki_mcp_server.py
+++ b/meraki-mcp-server/meraki_mcp_server.py
@@ -26,6 +26,7 @@ Author: Patrick Mosimann
 
 import httpx
 import os
+import sys
 import json
 import logging
 import jsonschema
@@ -85,7 +86,7 @@ if not api_key or api_key.startswith('your_actual_'):
     print("❌ MERAKI_KEY not configured properly!")
     print("📋 Please set your Meraki API key in .env file")
     print("   Example: MERAKI_KEY=your_actual_api_key_here")
-    exit(1)
+    sys.exit(1)
 
 print(f"✅ Meraki API key loaded: [CONFIGURED]")
 print(f"🌐 MCP Server will run on: http://{mcp_host}:{mcp_port}")

--- a/netbox-mcp-server/netbox_mcp_server.py
+++ b/netbox-mcp-server/netbox_mcp_server.py
@@ -24,6 +24,7 @@ Author: Patrick Mosimann
 
 import abc
 import os
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 import requests
@@ -72,13 +73,13 @@ if not netbox_url:
     print("❌ NETBOX_URL not configured!")
     print("📋 Please set your NetBox URL in .env file")
     print("   Example: NETBOX_URL=https://netbox.example.com")
-    exit(1)
+    sys.exit(1)
 
 if not netbox_token:
     print("❌ NETBOX_TOKEN not configured!")
     print("📋 Please set your NetBox API token in .env file")
     print("   Example: NETBOX_TOKEN=your_token_here")
-    exit(1)
+    sys.exit(1)
 
 print(f"✅ NetBox URL: {netbox_url}")
 print(f"✅ NetBox token configured")

--- a/thousandeyes-mcp-server/thousandeyes_mcp_server.py
+++ b/thousandeyes-mcp-server/thousandeyes_mcp_server.py
@@ -24,6 +24,7 @@ Based on: https://github.com/CiscoDevNet/thousandeyes-mcp-community
 """
 
 import os
+import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 import requests
@@ -371,7 +372,7 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"❌ Failed to connect to ThousandEyes API: {e}")
         print("💡 Please check your TE_TOKEN and network connectivity")
-        exit(1)
+        sys.exit(1)
     
     # Start the MCP server
     mcp.run(transport="http", host=mcp_host, port=mcp_port)


### PR DESCRIPTION
## Summary
Resolves CodeQL **py/use-of-exit-or-quit** warnings (#33–#38) by using `sys.exit(1)` instead of `exit(1)` for startup validation failures.

## Servers updated
- meraki-mcp-server
- netbox-mcp-server (2 call sites)
- catc-mcp-server
- ise-mcp-server
- thousandeyes-mcp-server

Splunk and netops-mcp-gateway already used `sys.exit()`.

## Test plan
- [ ] CodeQL passes on PR
- [ ] Merge to `main` and confirm alerts close

Made with [Cursor](https://cursor.com)